### PR TITLE
use portable types (long -> int64_t)

### DIFF
--- a/frnn/csrc/backward/backward.cu
+++ b/frnn/csrc/backward/backward.cu
@@ -2,8 +2,8 @@
 
 __global__ void FRNNBackward2DKernel(
     const float *__restrict__ points1, const float *__restrict__ points2,
-    const long *__restrict__ lengths1, const long *__restrict__ lengths2,
-    const long *__restrict__ idxs, const float *__restrict__ grad_dists,
+    const int64_t *__restrict__ lengths1, const int64_t *__restrict__ lengths2,
+    const int64_t *__restrict__ idxs, const float *__restrict__ grad_dists,
     float *__restrict__ grad_points1, float *__restrict__ grad_points2, int N,
     int P1, int P2, int K) {
   const int tid = blockIdx.x * blockDim.x + threadIdx.x;
@@ -16,10 +16,10 @@ __global__ void FRNNBackward2DKernel(
     const int k = rem / 2;
     const int d = rem % 2;
 
-    const long num1 = lengths1[n];
-    const long num2 = lengths2[n];
+    const int64_t num1 = lengths1[n];
+    const int64_t num2 = lengths2[n];
     if ((p1_idx < num1) && (k < num2)) {
-      const long p2_idx = idxs[n * P1 * K + p1_idx * K + k];
+      const int64_t p2_idx = idxs[n * P1 * K + p1_idx * K + k];
       if (p2_idx < 0)
         // sentinel value -1 indicating no fixed radius negihbors here
         continue;
@@ -37,8 +37,8 @@ __global__ void FRNNBackward2DKernel(
 /*
 __global__ void FRNNBackward3DKernel(
     const float *__restrict__ points1, const float *__restrict__ points2,
-    const long *__restrict__ lengths1, const long *__restrict__ lengths2,
-    const long *__restrict__ idxs, const float *__restrict__ grad_dists,
+    const int64_t *__restrict__ lengths1, const int64_t *__restrict__ lengths2,
+    const int64_t *__restrict__ idxs, const float *__restrict__ grad_dists,
     float *__restrict__ grad_points1, float *__restrict__ grad_points2, int N,
     int P1, int P2, int K) {
   const int tid = blockIdx.x * blockDim.x + threadIdx.x;
@@ -51,10 +51,10 @@ __global__ void FRNNBackward3DKernel(
     const int k = rem / 3;
     const int d = rem % 3;
 
-    const long num1 = lengths1[n];
-    const long num2 = lengths2[n];
+    const int64_t num1 = lengths1[n];
+    const int64_t num2 = lengths2[n];
     if ((p1_idx < num1) && (k < num2)) {
-      const long p2_idx = idxs[n * P1 * K + p1_idx * K + k];
+      const int64_t p2_idx = idxs[n * P1 * K + p1_idx * K + k];
       if (p2_idx < 0)
         // sentinel value -1 indicating no fixed radius negihbors here
         continue;
@@ -72,8 +72,8 @@ __global__ void FRNNBackward3DKernel(
 template <int D>
 __global__ void FRNNBackwardNDKernel(
     const float *__restrict__ points1, const float *__restrict__ points2,
-    const long *__restrict__ lengths1, const long *__restrict__ lengths2,
-    const long *__restrict__ idxs, const float *__restrict__ grad_dists,
+    const int64_t *__restrict__ lengths1, const int64_t *__restrict__ lengths2,
+    const int64_t *__restrict__ idxs, const float *__restrict__ grad_dists,
     float *__restrict__ grad_points1, float *__restrict__ grad_points2, int N,
     int P1, int P2, int K) {
   const int tid = blockIdx.x * blockDim.x + threadIdx.x;
@@ -86,10 +86,10 @@ __global__ void FRNNBackwardNDKernel(
     const int k = rem / D;
     const int d = rem % D;
 
-    const long num1 = lengths1[n];
-    const long num2 = lengths2[n];
+    const int64_t num1 = lengths1[n];
+    const int64_t num2 = lengths2[n];
     if ((p1_idx < num1) && (k < num2)) {
-      const long p2_idx = idxs[n * P1 * K + p1_idx * K + k];
+      const int64_t p2_idx = idxs[n * P1 * K + p1_idx * K + k];
       if (p2_idx < 0)
         // sentinel value -1 indicating no fixed radius negihbors here
         continue;
@@ -108,8 +108,8 @@ template <int D>
 struct FRNNBackwardNDKernelFunctor {
   static void run(
       int blocks, int threads, const float *__restrict__ points1,
-      const float *__restrict__ points2, const long *__restrict__ lengths1,
-      const long *__restrict__ lengths2, const long *__restrict__ idxs,
+      const float *__restrict__ points2, const int64_t *__restrict__ lengths1,
+      const int64_t *__restrict__ lengths2, const int64_t *__restrict__ idxs,
       const float *__restrict__ grad_dists, float *__restrict__ grad_points1,
       float *__restrict__ grad_points2, int N, int P1, int P2, int K) {
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -169,9 +169,9 @@ std::tuple<at::Tensor, at::Tensor> FRNNBackwardCUDA(
     FRNNBackward2DKernel<<<blocks, threads, 0, stream>>>(
         points1.contiguous().data_ptr<float>(),
         points2.contiguous().data_ptr<float>(),
-        lengths1.contiguous().data_ptr<long>(),
-        lengths2.contiguous().data_ptr<long>(),
-        idxs.contiguous().data_ptr<long>(),
+        lengths1.contiguous().data_ptr<int64_t>(),
+        lengths2.contiguous().data_ptr<int64_t>(),
+        idxs.contiguous().data_ptr<int64_t>(),
         grad_dists.contiguous().data_ptr<float>(),
         grad_points1.data_ptr<float>(), grad_points2.data_ptr<float>(), N, P1,
         P2, K);
@@ -179,9 +179,9 @@ std::tuple<at::Tensor, at::Tensor> FRNNBackwardCUDA(
     // FRNNBackward3DKernel<<<blocks, threads, 0, stream>>>(
     //     points1.contiguous().data_ptr<float>(),
     //     points2.contiguous().data_ptr<float>(),
-    //     lengths1.contiguous().data_ptr<long>(),
-    //     lengths2.contiguous().data_ptr<long>(),
-    //     idxs.contiguous().data_ptr<long>(),
+    //     lengths1.contiguous().data_ptr<int64_t>(),
+    //     lengths2.contiguous().data_ptr<int64_t>(),
+    //     idxs.contiguous().data_ptr<int64_t>(),
     //     grad_dists.contiguous().data_ptr<float>(),
     //     grad_points1.data_ptr<float>(), grad_points2.data_ptr<float>(), N,
     //     P1, P2, K);
@@ -189,9 +189,9 @@ std::tuple<at::Tensor, at::Tensor> FRNNBackwardCUDA(
     DispatchKernel1D<FRNNBackwardNDKernelFunctor, V0_MIN_D, V0_MAX_D>(
         D, blocks, threads, points1.contiguous().data_ptr<float>(),
         points2.contiguous().data_ptr<float>(),
-        lengths1.contiguous().data_ptr<long>(),
-        lengths2.contiguous().data_ptr<long>(),
-        idxs.contiguous().data_ptr<long>(),
+        lengths1.contiguous().data_ptr<int64_t>(),
+        lengths2.contiguous().data_ptr<int64_t>(),
+        idxs.contiguous().data_ptr<int64_t>(),
         grad_dists.contiguous().data_ptr<float>(),
         grad_points1.data_ptr<float>(), grad_points2.data_ptr<float>(), N, P1,
         P2, K);

--- a/frnn/csrc/grid/counting_sort.cu
+++ b/frnn/csrc/grid/counting_sort.cu
@@ -2,7 +2,7 @@
 
 __global__ void CountingSort2DKernel(
     const float *__restrict__ points,   // (N, P, 2)
-    const long *__restrict__ lengths,   // (N,)
+    const int64_t *__restrict__ lengths,   // (N,)
     const int *__restrict__ grid_cell,  // (N, P)
     const int *__restrict__ grid_idx,   // (N, P)
     const int *__restrict__ grid_off,   // (N, G)
@@ -35,7 +35,7 @@ __global__ void CountingSort2DKernel(
 /*
 __global__ void CountingSort3DKernel(
     const float *__restrict__ points,      // (N, P, 3)
-    const long *__restrict__ lengths,      // (N,)
+    const int64_t *__restrict__ lengths,      // (N,)
     const int *__restrict__ grid_cell,     // (N, P)
     const int *__restrict__ grid_idx,      // (N, P)
     const int *__restrict__ grid_off,      // (N, G)
@@ -71,7 +71,7 @@ __global__ void CountingSort3DKernel(
 template <int D>
 __global__ void CountingSortNDKernel(
     const float *__restrict__ points,      // (N, P, 3)
-    const long *__restrict__ lengths,      // (N,)
+    const int64_t *__restrict__ lengths,      // (N,)
     const int *__restrict__ grid_cell,     // (N, P)
     const int *__restrict__ grid_idx,      // (N, P)
     const int *__restrict__ grid_off,      // (N, G)
@@ -105,7 +105,7 @@ __global__ void CountingSortNDKernel(
 template <int D>
 struct CountingSortNDKernelFunctor {
   static void run(int blocks, int threads, const float *__restrict__ points,
-                  const long *__restrict__ lengths,
+                  const int64_t *__restrict__ lengths,
                   const int *__restrict__ grid_cell,
                   const int *__restrict__ grid_idx,
                   const int *__restrict__ grid_off,
@@ -151,7 +151,7 @@ void CountingSortCUDA(const at::Tensor points, const at::Tensor lengths,
   if (D == 2) {
     CountingSort2DKernel<<<blocks, threads, 0, stream>>>(
         points.contiguous().data_ptr<float>(),
-        lengths.contiguous().data_ptr<long>(),
+        lengths.contiguous().data_ptr<int64_t>(),
         grid_cell.contiguous().data_ptr<int>(),
         grid_idx.contiguous().data_ptr<int>(),
         grid_off.contiguous().data_ptr<int>(),
@@ -160,7 +160,7 @@ void CountingSortCUDA(const at::Tensor points, const at::Tensor lengths,
   } else {
     // CountingSort3DKernel<<<blocks, threads, 0, stream>>>(
     //     points.contiguous().data_ptr<float>(),
-    //     lengths.contiguous().data_ptr<long>(),
+    //     lengths.contiguous().data_ptr<int64_t>(),
     //     grid_cell.contiguous().data_ptr<int>(),
     //     grid_idx.contiguous().data_ptr<int>(),
     //     grid_off.contiguous().data_ptr<int>(),
@@ -169,7 +169,7 @@ void CountingSortCUDA(const at::Tensor points, const at::Tensor lengths,
 
     DispatchKernel1D<CountingSortNDKernelFunctor, V0_MIN_D, V0_MAX_D>(
         D, blocks, threads, points.contiguous().data_ptr<float>(),
-        lengths.contiguous().data_ptr<long>(),
+        lengths.contiguous().data_ptr<int64_t>(),
         grid_cell.contiguous().data_ptr<int>(),
         grid_idx.contiguous().data_ptr<int>(),
         grid_off.contiguous().data_ptr<int>(),

--- a/frnn/csrc/grid/counting_sort_cpu.cpp
+++ b/frnn/csrc/grid/counting_sort_cpu.cpp
@@ -6,7 +6,7 @@ void CountingSortCPU(const at::Tensor points, const at::Tensor lengths,
                      at::Tensor sorted_point_idx) {
 
   auto points_a = points.accessor<float, 3>();
-  auto lengths_a = lengths.accessor<long, 1>();
+  auto lengths_a = lengths.accessor<int64_t, 1>();
   auto grid_cell_a = grid_cell.accessor<int, 2>();
   auto grid_idx_a = grid_idx.accessor<int, 2>();
   auto grid_off_a = grid_off.accessor<int, 2>();

--- a/frnn/csrc/grid/find_nbrs.cu
+++ b/frnn/csrc/grid/find_nbrs.cu
@@ -2,12 +2,12 @@
 
 __global__ void FindNbrs2DKernelV1(
     const float *__restrict__ points1, const float *__restrict__ points2,
-    const long *__restrict__ lengths1, const long *__restrict__ lengths2,
+    const int64_t *__restrict__ lengths1, const int64_t *__restrict__ lengths2,
     const int *__restrict__ pc2_grid_off,
     const int *__restrict__ sorted_points1_idxs,
     const int *__restrict__ sorted_points2_idxs,
     const float *__restrict__ params, float *__restrict__ dists,
-    long *__restrict__ idxs, int N, int P1, int P2, int G, int K,
+    int64_t *__restrict__ idxs, int N, int P1, int P2, int G, int K,
     const float *__restrict__ rs, const float *__restrict__ r2s) {
   int chunks_per_cloud = (1 + (P1 - 1) / blockDim.x);
   int chunks_to_do = N * chunks_per_cloud;
@@ -43,7 +43,7 @@ __global__ void FindNbrs2DKernelV1(
         (int)std::floor((cur_point.y - grid_min_y + cur_r) * grid_delta);
     // use global memory directly
     int offset = n * P1 * K + old_p1 * K;
-    MinK<float, long> mink(dists + offset, idxs + offset, K);
+    MinK<float, int64_t> mink(dists + offset, idxs + offset, K);
     for (int x = max(min_gc_x, 0); x <= min(max_gc_x, grid_res_x - 1); ++x) {
       for (int y = max(min_gc_y, 0); y <= min(max_gc_y, grid_res_y - 1); ++y) {
         int cell_idx = x * grid_res_y + y;
@@ -77,12 +77,12 @@ __global__ void FindNbrs2DKernelV1(
 template <int K>
 __global__ void FindNbrs2DKernelV2(
     const float *__restrict__ points1, const float *__restrict__ points2,
-    const long *__restrict__ lengths1, const long *__restrict__ lengths2,
+    const int64_t *__restrict__ lengths1, const int64_t *__restrict__ lengths2,
     const int *__restrict__ pc2_grid_off,
     const int *__restrict__ sorted_points1_idxs,
     const int *__restrict__ sorted_points2_idxs,
     const float *__restrict__ params, float *__restrict__ dists,
-    long *__restrict__ idxs, int N, int P1, int P2, int G,
+    int64_t *__restrict__ idxs, int N, int P1, int P2, int G,
     const float *__restrict__ rs, const float *__restrict__ r2s) {
   float min_dists[K];
   int min_idxs[K];
@@ -155,12 +155,12 @@ __global__ void FindNbrs2DKernelV2(
 template <int K>
 __global__ void FindNbrs3DKernel(
     const float *__restrict__ points1, const float *__restrict__ points2,
-    const long *__restrict__ lengths1, const long *__restrict__ lengths2,
+    const int64_t *__restrict__ lengths1, const int64_t *__restrict__ lengths2,
     const int *__restrict__ pc2_grid_off,
     const int *__restrict__ sorted_points1_idxs,
     const int *__restrict__ sorted_points2_idxs,
     const float *__restrict__ params, float *__restrict__ dists,
-    long *__restrict__ idxs, int N, int P1, int P2, int G,
+    int64_t *__restrict__ idxs, int N, int P1, int P2, int G,
     const float *__restrict__ rs, const float *__restrict__ r2s) {
   float min_dists[K];
   int min_idxs[K];
@@ -243,12 +243,12 @@ __global__ void FindNbrs3DKernel(
 
 __global__ void FindNbrsNDKernelV0(
     const float *__restrict__ points1, const float *__restrict__ points2,
-    const long *__restrict__ lengths1, const long *__restrict__ lengths2,
+    const int64_t *__restrict__ lengths1, const int64_t *__restrict__ lengths2,
     const int *__restrict__ pc2_grid_off,
     const int *__restrict__ sorted_points1_idxs,
     const int *__restrict__ sorted_points2_idxs,
     const float *__restrict__ params, float *__restrict__ dists,
-    long *__restrict__ idxs, int N, int P1, int P2, int G, int D, int K,
+    int64_t *__restrict__ idxs, int N, int P1, int P2, int G, int D, int K,
     const float *__restrict__ rs, const float *__restrict__ r2s) {
   // access all the data in global memory directly
   float3 cur_point_3;
@@ -291,7 +291,7 @@ __global__ void FindNbrsNDKernelV0(
     int max_gc_z =
         (int)std::floor((cur_point_3.z - grid_min_z + cur_r) * grid_delta);
     int offset = n * P1 * K + old_p1 * K;
-    MinK<float, long> mink(dists + offset, idxs + offset, K);
+    MinK<float, int64_t> mink(dists + offset, idxs + offset, K);
     for (int x = max(min_gc_x, 0); x <= min(max_gc_x, grid_res_x - 1); ++x) {
       for (int y = max(min_gc_y, 0); y <= min(max_gc_y, grid_res_y - 1); ++y) {
         for (int z = max(min_gc_z, 0); z <= min(max_gc_z, grid_res_z - 1);
@@ -331,12 +331,12 @@ __global__ void FindNbrsNDKernelV0(
 template <int D>
 __global__ void FindNbrsNDKernelV1(
     const float *__restrict__ points1, const float *__restrict__ points2,
-    const long *__restrict__ lengths1, const long *__restrict__ lengths2,
+    const int64_t *__restrict__ lengths1, const int64_t *__restrict__ lengths2,
     const int *__restrict__ pc2_grid_off,
     const int *__restrict__ sorted_points1_idxs,
     const int *__restrict__ sorted_points2_idxs,
     const float *__restrict__ params, float *__restrict__ dists,
-    long *__restrict__ idxs, int N, int P1, int P2, int G, int K,
+    int64_t *__restrict__ idxs, int N, int P1, int P2, int G, int K,
     const float *__restrict__ rs, const float *__restrict__ r2s) {
   float cur_point[D];
 
@@ -379,7 +379,7 @@ __global__ void FindNbrsNDKernelV1(
     int max_gc_z =
         (int)std::floor((cur_point[2] - grid_min_z + cur_r) * grid_delta);
     int offset = n * P1 * K + old_p1 * K;
-    MinK<float, long> mink(dists + offset, idxs + offset, K);
+    MinK<float, int64_t> mink(dists + offset, idxs + offset, K);
     for (int x = max(min_gc_x, 0); x <= min(max_gc_x, grid_res_x - 1); ++x) {
       for (int y = max(min_gc_y, 0); y <= min(max_gc_y, grid_res_y - 1); ++y) {
         for (int z = max(min_gc_z, 0); z <= min(max_gc_z, grid_res_z - 1);
@@ -418,12 +418,12 @@ __global__ void FindNbrsNDKernelV1(
 template <int D, int K>
 __global__ void FindNbrsNDKernelV2(
     const float *__restrict__ points1, const float *__restrict__ points2,
-    const long *__restrict__ lengths1, const long *__restrict__ lengths2,
+    const int64_t *__restrict__ lengths1, const int64_t *__restrict__ lengths2,
     const int *__restrict__ pc2_grid_off,
     const int *__restrict__ sorted_points1_idxs,
     const int *__restrict__ sorted_points2_idxs,
     const float *__restrict__ params, float *__restrict__ dists,
-    long *__restrict__ idxs, int N, int P1, int P2, int G,
+    int64_t *__restrict__ idxs, int N, int P1, int P2, int G,
     const float *__restrict__ rs, const float *__restrict__ r2s) {
   float min_dists[K];
   int min_idxs[K];
@@ -508,14 +508,14 @@ struct FindNbrsKernelV1Functor {
   static void run(int blocks, int threads,
                   const float *__restrict__ points1,            // (N, P1, D)
                   const float *__restrict__ points2,            // (N, P2, D)
-                  const long *__restrict__ lengths1,            // (N,)
-                  const long *__restrict__ lengths2,            // (N,)
+                  const int64_t *__restrict__ lengths1,            // (N,)
+                  const int64_t *__restrict__ lengths2,            // (N,)
                   const int *__restrict__ pc2_grid_off,         // (N, G)
                   const int *__restrict__ sorted_points1_idxs,  // (N, P)
                   const int *__restrict__ sorted_points2_idxs,  // (N, P)
                   const float *__restrict__ params,             // (N,)
                   float *__restrict__ dists,                    // (N, P1, K)
-                  long *__restrict__ idxs,                      // (N, P1, K)
+                  int64_t *__restrict__ idxs,                      // (N, P1, K)
                   int N, int P1, int P2, int G, int K, const float *rs,
                   const float *r2s) {
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -542,14 +542,14 @@ struct FindNbrsKernelV2Functor {
   static void run(int blocks, int threads,
                   const float *__restrict__ points1,            // (N, P1, D)
                   const float *__restrict__ points2,            // (N, P2, D)
-                  const long *__restrict__ lengths1,            // (N,)
-                  const long *__restrict__ lengths2,            // (N,)
+                  const int64_t *__restrict__ lengths1,            // (N,)
+                  const int64_t *__restrict__ lengths2,            // (N,)
                   const int *__restrict__ pc2_grid_off,         // (N, G)
                   const int *__restrict__ sorted_points1_idxs,  // (N, P)
                   const int *__restrict__ sorted_points2_idxs,  // (N, P)
                   const float *__restrict__ params,             // (N,)
                   float *__restrict__ dists,                    // (N, P1, K)
-                  long *__restrict__ idxs,                      // (N, P1, K)
+                  int64_t *__restrict__ idxs,                      // (N, P1, K)
                   int N, int P1, int P2, int G, const float *rs,
                   const float *r2s) {
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -634,51 +634,51 @@ std::tuple<at::Tensor, at::Tensor> FindNbrsCUDA(
   // DispatchKernel1D<FindNbrsKernelFunctor, MIN_K, MAX_K>(
   //     K, blocks, threads, D, points1.contiguous().data_ptr<float>(),
   //     points2.contiguous().data_ptr<float>(),
-  //     lengths1.contiguous().data_ptr<long>(),
-  //     lengths2.contiguous().data_ptr<long>(),
+  //     lengths1.contiguous().data_ptr<int64_t>(),
+  //     lengths2.contiguous().data_ptr<int64_t>(),
   //     pc2_grid_off.contiguous().data_ptr<int>(),
   //     sorted_points1_idxs.contiguous().data_ptr<int>(),
   //     sorted_points2_idxs.contiguous().data_ptr<int>(),
   //     params.contiguous().data_ptr<float>(), dists.data_ptr<float>(),
-  //     idxs.data_ptr<long>(), N, P1, P2, G, rs.data_ptr<float>(),
+  //     idxs.data_ptr<int64_t>(), N, P1, P2, G, rs.data_ptr<float>(),
   //     r2s.data_ptr<float>());
   if (version == 0) {
     assert(D > 2);
     FindNbrsNDKernelV0<<<blocks, threads, 0, stream>>>(
         points1.contiguous().data_ptr<float>(),
         points2.contiguous().data_ptr<float>(),
-        lengths1.contiguous().data_ptr<long>(),
-        lengths2.contiguous().data_ptr<long>(),
+        lengths1.contiguous().data_ptr<int64_t>(),
+        lengths2.contiguous().data_ptr<int64_t>(),
         pc2_grid_off.contiguous().data_ptr<int>(),
         sorted_points1_idxs.contiguous().data_ptr<int>(),
         sorted_points2_idxs.contiguous().data_ptr<int>(),
         params.contiguous().data_ptr<float>(), dists.data_ptr<float>(),
-        idxs.data_ptr<long>(), N, P1, P2, G, D, K, rs.data_ptr<float>(),
+        idxs.data_ptr<int64_t>(), N, P1, P2, G, D, K, rs.data_ptr<float>(),
         r2s.data_ptr<float>());
   } else if (version == 1) {
     DispatchKernel1D<FindNbrsKernelV1Functor, V1_MIN_D, V1_MAX_D>(
         D, blocks, threads, points1.contiguous().data_ptr<float>(),
         points2.contiguous().data_ptr<float>(),
-        lengths1.contiguous().data_ptr<long>(),
-        lengths2.contiguous().data_ptr<long>(),
+        lengths1.contiguous().data_ptr<int64_t>(),
+        lengths2.contiguous().data_ptr<int64_t>(),
         pc2_grid_off.contiguous().data_ptr<int>(),
         sorted_points1_idxs.contiguous().data_ptr<int>(),
         sorted_points2_idxs.contiguous().data_ptr<int>(),
         params.contiguous().data_ptr<float>(), dists.data_ptr<float>(),
-        idxs.data_ptr<long>(), N, P1, P2, G, K, rs.data_ptr<float>(),
+        idxs.data_ptr<int64_t>(), N, P1, P2, G, K, rs.data_ptr<float>(),
         r2s.data_ptr<float>());
   } else if (version == 2) {
     DispatchKernel2D<FindNbrsKernelV2Functor, V2_MIN_D, V2_MAX_D, V2_MIN_K,
                      V2_MAX_K>(
         D, K, blocks, threads, points1.contiguous().data_ptr<float>(),
         points2.contiguous().data_ptr<float>(),
-        lengths1.contiguous().data_ptr<long>(),
-        lengths2.contiguous().data_ptr<long>(),
+        lengths1.contiguous().data_ptr<int64_t>(),
+        lengths2.contiguous().data_ptr<int64_t>(),
         pc2_grid_off.contiguous().data_ptr<int>(),
         sorted_points1_idxs.contiguous().data_ptr<int>(),
         sorted_points2_idxs.contiguous().data_ptr<int>(),
         params.contiguous().data_ptr<float>(), dists.data_ptr<float>(),
-        idxs.data_ptr<long>(), N, P1, P2, G, rs.data_ptr<float>(),
+        idxs.data_ptr<int64_t>(), N, P1, P2, G, rs.data_ptr<float>(),
         r2s.data_ptr<float>());
   } else {
     AT_ASSERTM(false, "Invalid version for find_nbrs");

--- a/frnn/csrc/grid/find_nbrs_cpu.cpp
+++ b/frnn/csrc/grid/find_nbrs_cpu.cpp
@@ -27,15 +27,15 @@ std::tuple<at::Tensor, at::Tensor> FindNbrsCPU(
 
   auto points1_a = points1.accessor<float, 3>();
   auto points2_a = points2.accessor<float, 3>();
-  auto lengths1_a = lengths1.accessor<long, 1>();
-  auto lengths2_a = lengths2.accessor<long, 1>();
+  auto lengths1_a = lengths1.accessor<int64_t, 1>();
+  auto lengths2_a = lengths2.accessor<int64_t, 1>();
   auto grid_off_a = grid_off.accessor<int, 2>();
   auto sorted_point_idx_a = sorted_point_idx.accessor<int, 2>();
 
   auto idxs = at::full({N, P1, K}, -1, lengths1.options());
   auto dists = at::full({N, P1, K}, -1, points1.options());
 
-  auto idxs_a = idxs.accessor<long, 3>();
+  auto idxs_a = idxs.accessor<int64_t, 3>();
   auto dists_a = dists.accessor<float, 3>();
 
   for (int n = 0; n < N; ++n) {

--- a/frnn/csrc/grid/insert_points.cu
+++ b/frnn/csrc/grid/insert_points.cu
@@ -1,7 +1,7 @@
 #include "grid/insert_points.h"
 
 __global__ void InsertPoints2DKernel(const float *__restrict__ points,
-                                     const long *__restrict__ lengths,
+                                     const int64_t *__restrict__ lengths,
                                      const float *__restrict__ params,
                                      int *__restrict__ grid_cnt,
                                      int *__restrict__ grid_cell,
@@ -35,7 +35,7 @@ __global__ void InsertPoints2DKernel(const float *__restrict__ points,
 
 /*
 __global__ void InsertPoints3DKernel(const float *__restrict__ points,
-                                     const long *__restrict__ lengths,
+                                     const int64_t *__restrict__ lengths,
                                      const float *__restrict__ params,
                                      int *__restrict__ grid_cnt,
                                      int *__restrict__ grid_cell,
@@ -74,7 +74,7 @@ __global__ void InsertPoints3DKernel(const float *__restrict__ points,
 
 template <int D>
 __global__ void InsertPointsNDKernel(const float *__restrict__ points,
-                                     const long *__restrict__ lengths,
+                                     const int64_t *__restrict__ lengths,
                                      const float *__restrict__ params,
                                      int *__restrict__ grid_cnt,
                                      int *__restrict__ grid_cell,
@@ -113,7 +113,7 @@ __global__ void InsertPointsNDKernel(const float *__restrict__ points,
 template <int D>
 struct InsertPointsNDKernelFunctor {
   static void run(int blocks, int threads, const float *__restrict__ points,
-                  const long *__restrict__ lengths,
+                  const int64_t *__restrict__ lengths,
                   const float *__restrict__ params, int *__restrict__ grid_cnt,
                   int *__restrict__ grid_cell, int *__restrict__ grid_idx,
                   int N, int P, int G) {
@@ -152,7 +152,7 @@ void InsertPointsCUDA(const at::Tensor points,   // (N, P, D)
   if (D == 2) {
     InsertPoints2DKernel<<<blocks, threads, 0, stream>>>(
         points.contiguous().data_ptr<float>(),
-        lengths.contiguous().data_ptr<long>(),
+        lengths.contiguous().data_ptr<int64_t>(),
         params.contiguous().data_ptr<float>(),
         grid_cnt.contiguous().data_ptr<int>(),
         grid_cell.contiguous().data_ptr<int>(),
@@ -161,7 +161,7 @@ void InsertPointsCUDA(const at::Tensor points,   // (N, P, D)
     // } else if (D == 3) {
     //   InsertPoints3DKernel<<<blocks, threads, 0, stream>>>(
     //       points.contiguous().data_ptr<float>(),
-    //       lengths.contiguous().data_ptr<long>(),
+    //       lengths.contiguous().data_ptr<int64_t>(),
     //       params.contiguous().data_ptr<float>(),
     //       grid_cnt.contiguous().data_ptr<int>(),
     //       grid_cell.contiguous().data_ptr<int>(),
@@ -170,7 +170,7 @@ void InsertPointsCUDA(const at::Tensor points,   // (N, P, D)
   } else {
     DispatchKernel1D<InsertPointsNDKernelFunctor, V0_MIN_D, V0_MAX_D>(
         D, blocks, threads, points.contiguous().data_ptr<float>(),
-        lengths.contiguous().data_ptr<long>(),
+        lengths.contiguous().data_ptr<int64_t>(),
         params.contiguous().data_ptr<float>(),
         grid_cnt.contiguous().data_ptr<int>(),
         grid_cell.contiguous().data_ptr<int>(),

--- a/frnn/csrc/grid/insert_points_cpu.cpp
+++ b/frnn/csrc/grid/insert_points_cpu.cpp
@@ -13,7 +13,7 @@ void InsertPointsCPU(const at::Tensor points, const at::Tensor lengths,
                      at::Tensor grid_next, at::Tensor grid_idx,
                      GridParams *params) {
   auto points_a = points.accessor<float, 3>();
-  auto lengths_a = lengths.accessor<long, 1>();
+  auto lengths_a = lengths.accessor<int64_t, 1>();
   auto grid_a = grid.accessor<int, 2>();
   auto grid_cnt_a = grid_cnt.accessor<int, 2>();
   auto grid_cell_a = grid_cell.accessor<int, 2>();


### PR DESCRIPTION
The current code uses the `long` type, it is not a portable. When compiling the code using MSVC++, it causes us to run into `LNK2001: unresolved external symbol ...` errors. Changing the code to use `int64_t` fixes these errors, which allows one to build FRNN on Windows.

I am trying to get `superpoint_transformer` which depends on this library to build on Windows, and this is currently one of the build blockers. I have not tested this by rebuilding on Linux, but I assume the changes should not break anything there.